### PR TITLE
Minor polish.

### DIFF
--- a/sdk-gen/subprojects/java/bundle/build.gradle
+++ b/sdk-gen/subprojects/java/bundle/build.gradle
@@ -21,11 +21,7 @@ dependencies {
 
   testImplementation project(':wdp-connect-sdk-gen-java-test')
   testImplementation project(':wdp-connect-sdk-gen-java-util')
-  if (!JavaVersion.current().isJava9Compatible()) {
-    testImplementation group: 'org.apache.derby', name: 'derbynet', version: project['derby.java8.version']
-  } else {
-    testImplementation group: 'org.apache.derby', name: 'derbynet', version: project['derby.version']
-  }
+  testImplementation group: 'org.apache.derby', name: 'derbynet', version: project['derby.version']
   testImplementation group: 'junit', name: 'junit', version: project['junit.version']
   testRuntimeOnly group: 'io.grpc', name: 'grpc-all', version: project['grpc.version']
   testRuntimeOnly group: 'io.netty', name: 'netty-all', version: project['netty.version']

--- a/sdk-gen/subprojects/java/bundle/src/test/java/com/ibm/connect/sdk/bundle/BundleTestEnvironment.java
+++ b/sdk-gen/subprojects/java/bundle/src/test/java/com/ibm/connect/sdk/bundle/BundleTestEnvironment.java
@@ -113,8 +113,8 @@ public class BundleTestEnvironment
             testFlight = TestFlight.createLocal(TestConfig.getPort("bundle.flight.port"), useSSL, new BundleFlightProducer());
         } else {
             final boolean verifyCert = Boolean.parseBoolean(TestConfig.get("bundle.flight.ssl_certificate_validation", "true"));
-            testFlight = TestFlight.createRemote(TestConfig.get("bundle.flight.uri"), TestConfig.get("bundle.flight.ssl_certificate"),
-                    verifyCert);
+            testFlight = TestFlight.createRemote(TestConfig.get("bundle.flight.uri.internal",TestConfig.get("bundle.flight.uri")),
+                    TestConfig.get("bundle.flight.ssl_certificate"), verifyCert);
         }
         client = testFlight.getClient();
         derbyServer = DerbyUtils.startServer(DERBY_HOST, DERBY_PORT, DERBY_USER, DERBY_PASSWORD);

--- a/sdk-gen/subprojects/java/jdbc/generic/build.gradle
+++ b/sdk-gen/subprojects/java/jdbc/generic/build.gradle
@@ -18,11 +18,7 @@ dependencies {
   implementation project(':wdp-connect-sdk-gen-java-jdbc')
   implementation project(':wdp-connect-sdk-gen-java-util')
   implementation group: 'org.apache.arrow', name: 'arrow-jdbc', version: project['arrow.version']
-  if (!JavaVersion.current().isJava9Compatible()) {
-    implementation group: 'org.apache.derby', name: 'derbyclient', version: project['derby.java8.version']
-  } else {
-    implementation group: 'org.apache.derby', name: 'derbyclient', version: project['derby.version']
-  }
+  implementation group: 'org.apache.derby', name: 'derbyclient', version: project['derby.version']
   implementation group: 'com.ibm.db2', name: 'jcc', version: project['db2jcc.version']
   implementation group: 'com.ibm.informix', name: 'jdbc', version: project['informix.version']
   implementation group: 'com.microsoft.sqlserver', name: 'mssql-jdbc', version: project['sqlserver.version']
@@ -33,11 +29,7 @@ dependencies {
   implementation group: 'org.postgresql', name: 'postgresql', version: project['postgresql.version']
 
   testImplementation project(':wdp-connect-sdk-gen-java-test')
-  if (!JavaVersion.current().isJava9Compatible()) {
-    testImplementation group: 'org.apache.derby', name: 'derbynet', version: project['derby.java8.version']
-  } else {
-    testImplementation group: 'org.apache.derby', name: 'derbynet', version: project['derby.version']
-  }
+  testImplementation group: 'org.apache.derby', name: 'derbynet', version: project['derby.version']
   testImplementation group: 'junit', name: 'junit', version: project['junit.version']
   testRuntimeOnly group: 'io.grpc', name: 'grpc-all', version: project['grpc.version']
   testRuntimeOnly group: 'io.netty', name: 'netty-all', version: project['netty.version']

--- a/sdk-operator/templates/Makefile
+++ b/sdk-operator/templates/Makefile
@@ -93,20 +93,20 @@ docker-push: ## Push docker image with the manager.
 
 .PHONY: install
 install: kustomize ## Install CRDs into the K8s cluster specified in ~/.kube/config.
-	$(KUSTOMIZE) build config/crd | kubectl apply -f -
+	$(KUSTOMIZE) build config/crd | oc apply -f -
 
 .PHONY: uninstall
 uninstall: kustomize ## Uninstall CRDs from the K8s cluster specified in ~/.kube/config.
-	$(KUSTOMIZE) build config/crd | kubectl delete -f -
+	$(KUSTOMIZE) build config/crd | oc delete -f -
 
 .PHONY: deploy
 deploy: kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
 	cd config/manager && ../../$(KUSTOMIZE) edit set image controller=${INTERNAL_IMG}
-	$(KUSTOMIZE) build config/default | kubectl apply -f -
+	$(KUSTOMIZE) build config/default | oc apply -f -
 
 .PHONY: undeploy
 undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/config.
-	$(KUSTOMIZE) build config/default | kubectl delete -f -
+	$(KUSTOMIZE) build config/default | oc delete -f -
 
 OS := $(shell uname -s | tr '[:upper:]' '[:lower:]')
 ARCH := $(shell uname -m | sed 's/x86_64/amd64/')


### PR DESCRIPTION
* added alternative uri property for remote flight client in tests. Client and server can run behind firewall while conn service might need to go through a tunnel in case of public cloud so I separated uri into two.
* replaced kubectl with oc in operator Makefile. There is no need to demand both oc and kubectl to be present, especially since I noticed the 'download client tools' option in openshift console only gives you oc.
* removed references to derby library for java 8 in projects since we don't use 8 anymore.
* Describe extra test property
* Added more implementation details in guide
* Changed the java requirement in docs from 8 to 11