### PR TITLE
Fix deploy-operator

### DIFF
--- a/sdk-operator/flightservice/build.gradle
+++ b/sdk-operator/flightservice/build.gradle
@@ -50,7 +50,7 @@ def osLogin = {
       standardOutput = stdout
       errorOutput = stderr
     }
-    if (!"Login successful.".equals(stdout.toString().split('\r|\n')[0])) {
+    if (!Arrays.asList(stdout.toString().split('\r|\n')).contains("Login successful.")) {
       println(stdout)
       println(stderr)
       throw new RuntimeException('Unable to log into the Openshift cluster. Check the openshift.console.url, openshift.username, and openshift.password properties.')


### PR DESCRIPTION
The deploy-operator step failed with the latest oc command line from 5.1, because the build script expected the first line of output from "oc login" to be "Login successful." which is no longer the case.  The first line of output is now "WARNING: Using insecure TLS client config. Setting this option is not supported!" and further lines of the output need to be searched to find the "Login successful." line.
Signed-off-by: Tom O'Shea <osheat@us.ibm.com>