### PR TITLE
feat: Add metadata fields to connector DSL for Forge tracking

### DIFF
--- a/.bob/rules-connectors-forge-rest/1_workflow.xml
+++ b/.bob/rules-connectors-forge-rest/1_workflow.xml
@@ -21,7 +21,7 @@
     </phase>
     
     <phase number="1">
-      <name>API Discovery & Analysis</name>
+      <name>API Discovery and Analysis</name>
       <file>1_workflow.xml (this file)</file>
       <description>
         Gather API information and analyze endpoint structures.
@@ -37,7 +37,7 @@
     </phase>
     
     <phase number="3">
-      <name>Presentation & Confirmation</name>
+      <name>Presentation and Confirmation</name>
       <file>1_workflow.xml (this file)</file>
       <description>
         Present configuration and gather user feedback.
@@ -76,7 +76,7 @@
     </phase>
     
     <phase number="7">
-      <name>Registration Validation & Testing</name>
+      <name>Registration Validation and Testing</name>
       <file>6_deployment_execution.xml</file>
       <description>
         Validate connector registration by running discovery tests.
@@ -89,7 +89,7 @@
   </workflow_phases>
 
   <phase_1_discovery>
-    <title>API Discovery & Analysis</title>
+    <title>API Discovery and Analysis</title>
     <description>
       Before generating any JSON configuration file, you MUST gather required information.
       Never proceed without complete information.
@@ -373,6 +373,104 @@
       <why>This is the ONLY allowed structural reference</why>
     </prerequisite>
 
+    <metadata_generation>
+      <title>Automatic Metadata Population</title>
+      <description>
+        All Forge-created connectors MUST include metadata section with auto-populated fields.
+        This metadata enables tracking, filtering, and analytics of Connector Forge usage.
+      </description>
+      
+      <auto_populated_fields>
+        <field name="connector_source">
+          <value>connector_forge</value>
+          <rule>Always hardcoded to "connector_forge"</rule>
+        </field>
+        
+        <field name="connector_type">
+          <value>rest_api</value>
+          <rule>Always hardcoded to "rest_api" for REST connectors</rule>
+        </field>
+        
+        <field name="created_at">
+          <format>ISO 8601 UTC timestamp</format>
+          <example>2026-05-06T12:00:00Z</example>
+          <rule>Auto-generate current timestamp when creating configuration</rule>
+        </field>
+        
+        <field name="forge_version">
+          <value>1.0.0</value>
+          <format>Semantic versioning</format>
+          <rule>Use current Connector Forge version</rule>
+        </field>
+        
+        <field name="created_by">
+          <description>User ID of the person creating the connector</description>
+          <rule>Extract from environment/context if available, otherwise use "unknown"</rule>
+          <default>unknown</default>
+        </field>
+      </auto_populated_fields>
+      
+      <user_confirmed_fields>
+        <field name="target_service">
+          <description>Name of the service/API being connected to</description>
+          <inference_process>
+            <step>1. Analyze the API hostname (e.g., api.salesforce.com → "Salesforce")</step>
+            <step>2. Extract service name from domain or API documentation</step>
+            <step>3. Present inference to user for confirmation</step>
+            <step>4. Allow user to override/customize if needed</step>
+          </inference_process>
+          <examples>
+            <example>
+              <hostname>https://api.spacexdata.com</hostname>
+              <inferred>SpaceX API</inferred>
+              <prompt>Based on the hostname 'api.spacexdata.com', I've identified this as "SpaceX API". Is this correct?</prompt>
+            </example>
+            <example>
+              <hostname>https://api.github.com</hostname>
+              <inferred>GitHub</inferred>
+              <prompt>Based on the hostname 'api.github.com', I've identified this as "GitHub". Is this correct?</prompt>
+            </example>
+            <example>
+              <hostname>https://login.salesforce.com</hostname>
+              <inferred>Salesforce</inferred>
+              <prompt>Based on the hostname 'login.salesforce.com', I've identified this as "Salesforce". Is this correct?</prompt>
+            </example>
+          </examples>
+          <user_interaction>
+            <question>I've identified the target service as "{inferred_name}". Is this correct?</question>
+            <options>
+              <option>Yes, that's correct</option>
+              <option>No, let me provide the correct name</option>
+            </options>
+          </user_interaction>
+        </field>
+      </user_confirmed_fields>
+      
+      <metadata_placement>
+        <rule>Metadata section must appear after $connector_description and before $hostname</rule>
+        <structure>
+          <![CDATA[
+{
+  "$connector_name": "...",
+  "$connector_label": "...",
+  "$connector_description": "...",
+  "$metadata": {
+    "connector_source": "connector_forge",
+    "target_service": "Service Name",
+    "connector_type": "rest_api",
+    "created_at": "2026-05-06T12:00:00Z",
+    "created_by": "user_12345",
+    "forge_version": "1.0.0"
+  },
+  "$hostname": "...",
+  "$authentication": "...",
+  "$tables": { ... }
+}
+          ]]>
+        </structure>
+      </metadata_placement>
+    </metadata_generation>
+
     <structure>
       <root_fields>
         <field name="$connector_name" required="true">
@@ -391,6 +489,41 @@
           <description>Brief description of what the connector provides</description>
           <example>Connector for SpaceX public REST API - provides access to rockets, launches, and more</example>
           <note>Use clear, descriptive sentences</note>
+        </field>
+        
+        <field name="$metadata" required="true">
+          <description>Metadata about the connector for tracking and analytics</description>
+          <auto_generated>true</auto_generated>
+          <fields>
+            <field name="connector_source">
+              <value>Always "connector_forge"</value>
+              <auto_populated>true</auto_populated>
+            </field>
+            <field name="target_service">
+              <description>Name of the service/API (e.g., "Salesforce", "GitHub", "SpaceX API")</description>
+              <inference>Inferred from hostname, confirmed with user</inference>
+              <example>SpaceX API</example>
+            </field>
+            <field name="connector_type">
+              <value>Always "rest_api"</value>
+              <auto_populated>true</auto_populated>
+            </field>
+            <field name="created_at">
+              <description>ISO 8601 timestamp of creation</description>
+              <auto_generated>true</auto_generated>
+              <example>2026-05-06T12:00:00Z</example>
+            </field>
+            <field name="created_by">
+              <description>User ID of creator</description>
+              <default>unknown</default>
+              <note>Extract from environment if available</note>
+            </field>
+            <field name="forge_version">
+              <description>Version of Connector Forge</description>
+              <format>Semantic versioning</format>
+              <example>1.0.0</example>
+            </field>
+          </fields>
         </field>
         
         <field name="$hostname" required="true">
@@ -574,7 +707,7 @@
   </phase_2_configuration_generation>
 
   <phase_3_presentation>
-    <title>Presentation & Confirmation</title>
+    <title>Presentation and Confirmation</title>
     
     <file_storage_location>
       <description>
@@ -634,6 +767,13 @@
   <validation_checklist>
     <title>Before Final Output</title>
     <checks>
+      <check>$metadata section is present with all required fields</check>
+      <check>connector_source is set to "connector_forge"</check>
+      <check>target_service is populated and confirmed with user</check>
+      <check>connector_type is set to "rest_api"</check>
+      <check>created_at is valid ISO 8601 timestamp</check>
+      <check>created_by is populated (or "unknown")</check>
+      <check>forge_version follows semantic versioning</check>
       <check>Each table has exactly one $path entry (array with single element)</check>
       <check>All nested objects are mapped with "[]" syntax</check>
       <check>All nested arrays are mapped as VARCHAR</check>

--- a/.bob/rules-connectors-forge-rest/4_best_practices.xml
+++ b/.bob/rules-connectors-forge-rest/4_best_practices.xml
@@ -131,6 +131,91 @@
     </rule>
 
     <rule priority="critical">
+      <name>Include Metadata Section</name>
+      <description>
+        All Forge-created connectors MUST include a $metadata section with required fields.
+        This metadata enables tracking, filtering, and analytics of Connector Forge usage.
+      </description>
+      <required_fields>
+        <field name="connector_source">
+          <type>String</type>
+          <value>Always "connector_forge" for Forge-created connectors</value>
+          <required>true</required>
+        </field>
+        <field name="target_service">
+          <type>String</type>
+          <description>Name of the service/API being connected to (e.g., "Salesforce", "GitHub", "SpaceX API")</description>
+          <required>true</required>
+          <inference>Should be inferred from API hostname and confirmed with user</inference>
+        </field>
+        <field name="connector_type">
+          <type>String</type>
+          <value>Always "rest_api" for REST connectors</value>
+          <required>true</required>
+        </field>
+        <field name="created_at">
+          <type>String</type>
+          <format>ISO 8601 timestamp (e.g., "2026-05-06T12:00:00Z")</format>
+          <required>true</required>
+          <auto_generated>true</auto_generated>
+        </field>
+        <field name="created_by">
+          <type>String</type>
+          <description>User ID of the person who created the connector</description>
+          <required>true</required>
+          <default>If unavailable, use "unknown"</default>
+        </field>
+        <field name="forge_version">
+          <type>String</type>
+          <description>Version of Connector Forge used to create the connector</description>
+          <required>true</required>
+          <format>Semantic versioning (e.g., "1.0.0")</format>
+        </field>
+      </required_fields>
+      <correct>
+        <![CDATA[
+{
+  "$connector_name": "salesforce-connector",
+  "$connector_label": "Salesforce",
+  "$connector_description": "Connect to Salesforce API",
+  "$metadata": {
+    "connector_source": "connector_forge",
+    "target_service": "Salesforce",
+    "connector_type": "rest_api",
+    "created_at": "2026-05-06T12:00:00Z",
+    "created_by": "user_12345",
+    "forge_version": "1.0.0"
+  },
+  "$hostname": "https://api.salesforce.com",
+  "$authentication": "oauth2",
+  "$tables": { ... }
+}
+        ]]>
+      </correct>
+      <wrong>
+        <![CDATA[
+{
+  "$connector_name": "salesforce_connector",
+  "$connector_label": "Salesforce",
+  "$connector_description": "Connect to Salesforce API",
+  "$hostname": "https://api.salesforce.com",
+  "$authentication": "oauth2",
+  "$tables": { ... }
+}
+        ]]>
+        <why>Missing required $metadata section</why>
+      </wrong>
+      <rationale>
+        Metadata enables:
+        - Distinguishing Forge-created connectors from manually-built ones
+        - Tracking which services users are connecting to
+        - Measuring Connector Forge adoption and usage patterns
+        - Providing audit trail for connector provenance
+        - Supporting future analytics and reporting capabilities
+      </rationale>
+    </rule>
+
+    <rule priority="critical">
       <name>Use Exact JSON Field Names</name>
       <description>
         Column names must match JSON field names exactly.
@@ -397,6 +482,10 @@
       <checklist>
         <check>JSON is valid and properly formatted</check>
         <check>All required root fields are present</check>
+        <check>$metadata section is present with all required fields</check>
+        <check>connector_source is set to "connector_forge"</check>
+        <check>target_service is populated and accurate</check>
+        <check>created_at is valid ISO 8601 timestamp</check>
         <check>Each table has exactly one $path entry</check>
         <check>At least one field per table is marked with ,$key</check>
         <check>All nested objects/arrays are VARCHAR</check>
@@ -611,8 +700,18 @@
     <categories>
       <category name="Structure">
         <check>JSON is valid (no syntax errors)</check>
-        <check>All required root fields present ($connector_name, $connector_label, $connector_description, $hostname, $authentication, $tables)</check>
+        <check>All required root fields present ($connector_name, $connector_label, $connector_description, $metadata, $hostname, $authentication, $tables)</check>
         <check>Follows connectors-forge/template.json structure exactly</check>
+      </category>
+
+      <category name="Metadata">
+        <check>$metadata section is present</check>
+        <check>connector_source is "connector_forge"</check>
+        <check>target_service is populated with service name</check>
+        <check>connector_type is "rest_api"</check>
+        <check>created_at is valid ISO 8601 timestamp</check>
+        <check>created_by is populated (or "unknown")</check>
+        <check>forge_version follows semantic versioning</check>
       </category>
 
       <category name="Tables">

--- a/connectors-forge/codeless/deploy-container.ps1
+++ b/connectors-forge/codeless/deploy-container.ps1
@@ -114,15 +114,38 @@ function Test-Inputs {
         Exit-WithError "Cannot connect via SSH or Docker not available on ${SshUser}@${SshHost}:${SshPort}"
     }
     
-    # Check if all config files exist
+    # Check if all config files exist and validate JSON
     $fileCount = 0
     foreach ($file in $Files) {
         if (-not (Test-Path $file)) {
             Exit-WithError "File not found: $file"
         }
+        
+        # Validate JSON syntax and metadata
+        try {
+            $jsonContent = Get-Content $file -Raw | ConvertFrom-Json
+            
+            # Check for required metadata fields
+            if (-not $jsonContent.'$metadata') {
+                Write-Host "WARNING: File $file is missing metadata section" -ForegroundColor Yellow
+            } else {
+                if (-not $jsonContent.'$metadata'.connector_source) {
+                    Write-Host "WARNING: File $file is missing 'connector_source' metadata field" -ForegroundColor Yellow
+                }
+                if (-not $jsonContent.'$metadata'.target_service) {
+                    Write-Host "WARNING: File $file is missing 'target_service' metadata field" -ForegroundColor Yellow
+                }
+                if (-not $jsonContent.'$metadata'.connector_type) {
+                    Write-Host "WARNING: File $file is missing 'connector_type' metadata field" -ForegroundColor Yellow
+                }
+            }
+        } catch {
+            Exit-WithError "Invalid JSON in file: $file - $_"
+        }
+        
         $fileCount++
     }
-    Write-Log "All $fileCount file(s) exist"
+    Write-Log "All $fileCount file(s) validated"
     
     # Validate port number
     if ($Port -lt 1 -or $Port -gt 65535) {

--- a/connectors-forge/codeless/deploy-container.sh
+++ b/connectors-forge/codeless/deploy-container.sh
@@ -204,15 +204,32 @@ validate_inputs() {
     fi
     log "SSH connection and Docker verified"
 
-    # Check if all config files exist
+    # Check if all config files exist and validate metadata
     local file_count=0
     for file in "${CONFIG_FILES[@]}"; do
         if [ ! -f "$file" ]; then
             error_exit "File not found: $file"
         fi
+        
+        # Validate JSON syntax
+        if ! python3 -m json.tool "$file" >/dev/null 2>&1; then
+            error_exit "Invalid JSON in file: $file"
+        fi
+        
+        # Check for required metadata fields
+        if ! grep -q '"connector_source"' "$file"; then
+            log "WARNING: File $file is missing 'connector_source' metadata field"
+        fi
+        if ! grep -q '"target_service"' "$file"; then
+            log "WARNING: File $file is missing 'target_service' metadata field"
+        fi
+        if ! grep -q '"connector_type"' "$file"; then
+            log "WARNING: File $file is missing 'connector_type' metadata field"
+        fi
+        
         file_count=$((file_count + 1))
     done
-    log "All $file_count file(s) exist"
+    log "All $file_count file(s) validated"
 
     # Validate port number
     if ! [[ "$PORT" =~ ^[0-9]+$ ]] || [ "$PORT" -lt 1 ] || [ "$PORT" -gt 65535 ]; then

--- a/connectors-forge/template.json
+++ b/connectors-forge/template.json
@@ -2,6 +2,14 @@
   "$connector_name": "api-name-connector",
   "$connector_label": "Display Label",
   "$connector_description": "Description of what this connector provides access to",
+  "$metadata": {
+    "connector_source": "connector_forge",
+    "target_service": "Example Service",
+    "connector_type": "rest_api",
+    "created_at": "2026-05-06T12:00:00Z",
+    "created_by": "user_12345",
+    "forge_version": "1.0.0"
+  },
   "$hostname": "https://api.example.com",
   "$authentication": "api_key",
   "$tables": {

--- a/guide.md
+++ b/guide.md
@@ -2141,3 +2141,82 @@ After making the changes you can run the build to undeploy and deploy the flight
 $ ./gradlew undeploy-operator
 $ ./gradlew deploy-operator
 ```
+
+
+# Connector Metadata
+
+## Overview
+Starting with version 1.0.0, all connectors created through Connector Forge include metadata fields in their DSL (JSON specification) to identify Forge-created connectors and track their target services. This metadata enables filtering, querying, and analytics of Connector Forge usage within the platform.
+
+## Metadata Structure
+
+All Forge-created connectors include a `$metadata` section in their connector specification with the following fields:
+
+```json
+{
+  "$connector_name": "salesforce_connector",
+  "$connector_label": "Salesforce",
+  "$connector_description": "Connect to Salesforce API",
+  "$metadata": {
+    "connector_source": "connector_forge",
+    "target_service": "Salesforce",
+    "connector_type": "rest_api",
+    "created_at": "2026-05-06T12:00:00Z",
+    "created_by": "user_12345",
+    "forge_version": "1.0.0"
+  },
+  "$hostname": "https://api.salesforce.com",
+  "$authentication": "oauth2",
+  "$tables": { ... }
+}
+```
+
+## Metadata Fields
+
+| Field | Type | Description | Auto-populated |
+|-------|------|-------------|----------------|
+| `connector_source` | String | Always set to "connector_forge" for Forge-created connectors | Yes |
+| `target_service` | String | Name of the service/API being connected to (e.g., "Salesforce", "GitHub") | Inferred, user-confirmed |
+| `connector_type` | String | Always set to "rest_api" for REST connectors | Yes |
+| `created_at` | String | ISO 8601 timestamp of when the connector was created | Yes |
+| `created_by` | String | User ID of the person who created the connector | Extracted from context or "unknown" |
+| `forge_version` | String | Version of Connector Forge used to create the connector | Yes |
+
+## Purpose and Benefits
+
+The metadata enables:
+
+1. **Connector Provenance**: Distinguish Forge-created connectors from manually-built ones
+2. **Service Tracking**: Identify which services/APIs users are connecting to
+3. **Usage Analytics**: Measure Connector Forge adoption and usage patterns
+4. **Filtering and Querying**: Query connectors by source, service, or creation date
+5. **Audit Trail**: Track who created connectors and when
+6. **Version Management**: Identify which Forge version was used
+
+## Metadata Lifecycle
+
+- **Creation**: Metadata is automatically populated when a connector is created through Connector Forge
+- **Updates**: Metadata persists through connector updates and regeneration
+- **Deployment**: Metadata is validated during deployment to ensure all required fields are present
+- **Registration**: Metadata is included in the datasource type definition when registered with Cloud Pak for Data
+
+## Target Service Inference
+
+The `target_service` field is automatically inferred from the API hostname during connector creation:
+
+- `api.salesforce.com` → "Salesforce"
+- `api.github.com` → "GitHub"  
+- `api.spacexdata.com` → "SpaceX API"
+
+Users are prompted to confirm or override the inferred service name to ensure accuracy.
+
+## Validation
+
+Deployment scripts automatically validate that:
+- The `$metadata` section is present
+- All required fields are populated
+- `connector_source` is set to "connector_forge"
+- `connector_type` is set to "rest_api"
+- `created_at` is a valid ISO 8601 timestamp
+
+Warnings are displayed if metadata fields are missing, but deployment continues to maintain backward compatibility with existing connectors.


### PR DESCRIPTION
Add metadata section to connector specifications to enable tracking and analytics of Connector Forge usage within the CP4D platform.

https://github.ibm.com/wdp-gov/tracker/issues/331131

## Metadata Schema

Added $metadata section with 6 fields:
- connector_source: "connector_forge" (identifies Forge-created connectors)
- target_service: Service/API name (e.g., "Salesforce", "GitHub")
- connector_type: "rest_api" (connector type)
- created_at: ISO 8601 timestamp
- created_by: User ID
- forge_version: Semantic version

## Changes

- template.json: Added metadata section with all required fields
- guide.md: Added "Connector Metadata" documentation section
- workflow.xml: Added metadata generation and validation rules
- best_practices.xml: Added metadata validation checklist
- deploy-container.sh/ps1: Added JSON and metadata validatio