### PR TITLE
feat: Add metadata field to CustomFlightDatasourceType

### DIFF
--- a/sdk-gen/subprojects/java/api/models/src/main/resources/sdk-openapi.yaml
+++ b/sdk-gen/subprojects/java/api/models/src/main/resources/sdk-openapi.yaml
@@ -233,6 +233,35 @@ components:
       type: object
       additionalProperties:
         type: string
+    DatasourceTypeMetadata:
+      description: Metadata about the datasource type origin and creation.
+      type: object
+      properties:
+        connector_source:
+          type: string
+          description: Source of the connector (e.g., "connector_forge", "library").
+          example: "connector_forge"
+        target_service:
+          type: string
+          description: Target service name (e.g., "GitHub", "Salesforce").
+          example: "GitHub"
+        connector_type:
+          type: string
+          description: Type of connector (e.g., "rest_api", "jdbc", "file").
+          example: "rest_api"
+        created_at:
+          type: string
+          format: date-time
+          description: ISO 8601 timestamp when connector was created.
+          example: "2026-05-06T13:00:00Z"
+        created_by:
+          type: string
+          description: User ID who created the connector.
+          example: "user_12345"
+        forge_version:
+          type: string
+          description: Version of Connector Forge used to create this connector.
+          example: "1.0.0"
     CustomFlightDatasourceType:
       description: The definition of a custom Arrow Flight data source type.
       type: object
@@ -269,6 +298,8 @@ components:
           type: array
           items:
             type: string
+        metadata:
+          $ref: '#/components/schemas/DatasourceTypeMetadata'
         actions:
           description: The actions supported for the data source.
           type: array

--- a/sdk-gen/subprojects/java/connectors_forge_rest/impl/src/main/java/com/ibm/connect/restconnector/RestApiMapping.java
+++ b/sdk-gen/subprojects/java/connectors_forge_rest/impl/src/main/java/com/ibm/connect/restconnector/RestApiMapping.java
@@ -21,6 +21,7 @@ public class RestApiMapping
     private final String baseUrl;
     private final AuthenticationType authenticationType;
     private final Map<String, RestTableDefinition> tables;
+    private final Map<String, String> metadata;
 
     /**
      * Creates an API mapping.
@@ -37,9 +38,12 @@ public class RestApiMapping
      *            the authentication type: "none", "api_key", "oauth2", or "basic" (from "$authentication")
      * @param tables
      *            a map of table name to table definition
+     * @param metadata
+     *            metadata from "$metadata" section (connector_source, target_service, etc.)
      */
     public RestApiMapping(String connectorName, String connectorLabel, String connectorDescription,
-            String baseUrl, AuthenticationType authenticationType, Map<String, RestTableDefinition> tables)
+            String baseUrl, AuthenticationType authenticationType, Map<String, RestTableDefinition> tables,
+            Map<String, String> metadata)
     {
         this.connectorName = connectorName;
         this.connectorLabel = connectorLabel;
@@ -47,6 +51,7 @@ public class RestApiMapping
         this.baseUrl = baseUrl;
         this.authenticationType = authenticationType != null ? authenticationType : AuthenticationType.NONE;
         this.tables = Collections.unmodifiableMap(new LinkedHashMap<>(tables));
+        this.metadata = metadata != null ? Collections.unmodifiableMap(new LinkedHashMap<>(metadata)) : Collections.emptyMap();
     }
 
     /**
@@ -140,11 +145,22 @@ public class RestApiMapping
         return tables.get(tableName.toUpperCase(java.util.Locale.ENGLISH));
     }
 
+    /**
+     * Returns the metadata map from the "$metadata" section of the connector configuration.
+     *
+     * @return an unmodifiable map of metadata (connector_source, target_service, connector_type, etc.)
+     */
+    public Map<String, String> getMetadata()
+    {
+        return metadata;
+    }
+
     @Override
     public String toString()
     {
         return "RestApiMapping{connectorName='" + connectorName + "', baseUrl='" + baseUrl
-                + "', authenticationType='" + authenticationType.getValue() + "', tables=" + tables.keySet() + "}";
+                + "', authenticationType='" + authenticationType.getValue() + "', tables=" + tables.keySet()
+                + ", metadata=" + metadata + "}";
     }
 }
 

--- a/sdk-gen/subprojects/java/connectors_forge_rest/impl/src/main/java/com/ibm/connect/restconnector/RestApiMappingLoader.java
+++ b/sdk-gen/subprojects/java/connectors_forge_rest/impl/src/main/java/com/ibm/connect/restconnector/RestApiMappingLoader.java
@@ -54,6 +54,7 @@ public class RestApiMappingLoader
     private static final String CONNECTOR_NAME_KEY = "$connector_name";
     private static final String CONNECTOR_LABEL_KEY = "$connector_label";
     private static final String CONNECTOR_DESCRIPTION_KEY = "$connector_description";
+    private static final String METADATA_KEY = "$metadata";
     private static final String HOSTNAME_KEY = "$hostname";
     private static final String AUTHENTICATION_KEY = "$authentication";
     private static final String TABLES_KEY = "$tables";
@@ -107,11 +108,12 @@ public class RestApiMappingLoader
         final String baseUrl = parseBaseUrl(root);
         final AuthenticationType authenticationType = parseAuthenticationType(root);
         final Map<String, RestTableDefinition> tables = parseTables(root);
+        final Map<String, String> metadataMap = parseMetadata(root);
 
-        LOGGER.info("Loaded REST API configuration: connectorName='{}', authenticationType='{}', {} tables",
-                metadata.connectorName, authenticationType.getValue(), tables.size());
+        LOGGER.info("Loaded REST API configuration: connectorName='{}', authenticationType='{}', {} tables, metadata={}",
+                metadata.connectorName, authenticationType.getValue(), tables.size(), metadataMap.isEmpty() ? "none" : metadataMap.keySet());
         return new RestApiMapping(metadata.connectorName, metadata.connectorLabel, metadata.connectorDescription,
-                baseUrl, authenticationType, tables);
+                baseUrl, authenticationType, tables, metadataMap);
     }
 
     private static ConnectorMetadata parseConnectorMetadata(JsonNode root)
@@ -120,6 +122,37 @@ public class RestApiMappingLoader
         final String connectorLabel = getTextOrDefault(root, CONNECTOR_LABEL_KEY, "REST Connector");
         final String connectorDescription = getTextOrDefault(root, CONNECTOR_DESCRIPTION_KEY, "REST API Connector");
         return new ConnectorMetadata(connectorName, connectorLabel, connectorDescription);
+    }
+
+    /**
+     * Parses the $metadata section from the JSON configuration.
+     *
+     * @param root
+     *            the root JSON node
+     * @return a map of metadata key-value pairs, or an empty map if no metadata is present
+     */
+    private static Map<String, String> parseMetadata(JsonNode root)
+    {
+        final Map<String, String> metadata = new LinkedHashMap<>();
+        final JsonNode metadataNode = root.get(METADATA_KEY);
+        
+        if (metadataNode != null && metadataNode.isObject()) {
+            final Iterator<Map.Entry<String, JsonNode>> fields = metadataNode.fields();
+            while (fields.hasNext()) {
+                final Map.Entry<String, JsonNode> field = fields.next();
+                final String key = field.getKey();
+                final JsonNode value = field.getValue();
+                
+                if (value != null && !value.isNull()) {
+                    metadata.put(key, value.asText());
+                }
+            }
+            LOGGER.debug("Parsed metadata: {}", metadata);
+        } else {
+            LOGGER.debug("No $metadata section found in configuration");
+        }
+        
+        return metadata;
     }
 
     private static String parseBaseUrl(JsonNode root) throws IOException

--- a/sdk-gen/subprojects/java/connectors_forge_rest/impl/src/main/java/com/ibm/connect/restconnector/RestDatasourceType.java
+++ b/sdk-gen/subprojects/java/connectors_forge_rest/impl/src/main/java/com/ibm/connect/restconnector/RestDatasourceType.java
@@ -7,13 +7,18 @@ package com.ibm.connect.restconnector;
 
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.text.SimpleDateFormat;
 import java.util.Collections;
+import java.util.Date;
+import java.util.Map;
+import java.util.TimeZone;
 
 import com.ibm.wdp.connect.common.sdk.api.models.CustomDatasourceTypeProperty;
 import com.ibm.wdp.connect.common.sdk.api.models.CustomDatasourceTypeProperty.TypeEnum;
 import com.ibm.wdp.connect.common.sdk.api.models.CustomFlightDatasourceType;
 import com.ibm.wdp.connect.common.sdk.api.models.CustomFlightDatasourceTypeProperties;
 import com.ibm.wdp.connect.common.sdk.api.models.DatasourceTypeDiscovery;
+import com.ibm.wdp.connect.common.sdk.api.models.DatasourceTypeMetadata;
 import com.ibm.wdp.connect.common.sdk.api.models.DiscoveryAssetType;
 import com.ibm.wdp.connect.common.sdk.api.models.DiscoveryPathProperty;
 import com.ibm.wdp.connect.common.sdk.api.models.DiscoveryPathSegment;
@@ -54,6 +59,33 @@ public class RestDatasourceType extends CustomFlightDatasourceType
         setAllowedAsTarget(false);
         setStatus(CustomFlightDatasourceType.StatusEnum.ACTIVE);
         setTags(Collections.emptyList());
+
+        // Set metadata from the $metadata section if present
+        final Map<String, String> metadataMap = mapping.getMetadata();
+        if (!metadataMap.isEmpty()) {
+            final DatasourceTypeMetadata metadata = new DatasourceTypeMetadata();
+            metadata.setConnectorSource(metadataMap.get("connector_source"));
+            metadata.setTargetService(metadataMap.get("target_service"));
+            metadata.setConnectorType(metadataMap.get("connector_type"));
+            metadata.setCreatedBy(metadataMap.get("created_by"));
+            metadata.setForgeVersion(metadataMap.get("forge_version"));
+            
+            // Parse created_at timestamp from ISO 8601 format string to Date
+            final String createdAtStr = metadataMap.get("created_at");
+            if (createdAtStr != null && !createdAtStr.isEmpty()) {
+                try {
+                    // Parse ISO 8601 date-time format (e.g., "2026-05-06T13:00:00Z")
+                    final SimpleDateFormat iso8601Format = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
+                    iso8601Format.setTimeZone(TimeZone.getTimeZone("UTC"));
+                    final Date createdAt = iso8601Format.parse(createdAtStr);
+                    metadata.setCreatedAt(createdAt);
+                } catch (Exception e) {
+                    // If parsing fails, skip setting created_at (field remains null)
+                }
+            }
+            
+            setMetadata(metadata);
+        }
 
         final CustomFlightDatasourceTypeProperties properties = new CustomFlightDatasourceTypeProperties();
         setProperties(properties);


### PR DESCRIPTION
- Added DatasourceTypeMetadata schema to OpenAPI spec
- Updated CustomFlightDatasourceType to include metadata field
- Generated Java classes from updated OpenAPI schema
- Extended RestApiMapping to store metadata from $metadata section
- Updated RestApiMappingLoader to parse $metadata from JSON config
- Modified RestDatasourceType to populate metadata field from config

This enables Forge connectors to expose metadata (connector_source, target_service, connector_type, etc.) in list_datasource_types response.